### PR TITLE
fix: Crash after loading apps and filtering at the same time

### DIFF
--- a/app/src/main/java/icu/nullptr/hidemyapplist/util/PackageHelper.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/util/PackageHelper.kt
@@ -53,7 +53,7 @@ object PackageHelper {
     private lateinit var pm: PackageManager
 
     private val packageCache = MutableSharedFlow<Map<String, PackageCache>>(replay = 1)
-    private val mAppList = MutableSharedFlow<MutableList<String>>(replay = 1)
+    private val mAppList = MutableSharedFlow<List<String>>(replay = 1)
     val appList: SharedFlow<List<String>> = mAppList
 
     private val mRefreshing = MutableSharedFlow<Boolean>(replay = 1)
@@ -80,7 +80,7 @@ object PackageHelper {
                 }
             }
             packageCache.emit(cache)
-            mAppList.emit(cache.keys.toMutableList())
+            mAppList.emit(cache.keys.toList())
             mRefreshing.emit(false)
         }
     }
@@ -93,8 +93,7 @@ object PackageHelper {
             PrefManager.SortMethod.BY_UPDATE_TIME -> Comparators.byUpdateTime
         }
         if (PrefManager.appFilter_reverseOrder) comparator = comparator.reversed()
-        val list = mAppList.first()
-        list.sortWith(firstComparator.then(comparator))
+        val list = mAppList.first().sortedWith(firstComparator.then(comparator))
         mAppList.emit(list)
     }
 


### PR DESCRIPTION
当应用管理在加载应用时，切换右上角的过滤选项，加载完成后会空指针闪退。

其原因是PackageHelper中mAppList是MutableList，sortList函数会改变其内容，AppSelectAdapter中的Filter在加载应用时performFiltering获取appList会出现ConcurrentModificationException，导致publishResults取得的results为null，进而转换成List<String>时因空指针闪退。

将MutableSharedFlow<MutableList>改为了MutableSharedFlow<List>来解决这个问题，本机测试不再闪退。