### PR TITLE
Why is there no issues tab present? 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ You can contribute translation [here](https://crowdin.com/project/hide-my-applis
 
 ## Update Log
 [Reference to the release page](https://github.com/Dr-TSNG/Hide-My-Applist/releases)  
+
+
+
+Why is there no issues tab?


### PR DESCRIPTION
Please enable the issues tab so users can have a discussion and post issues. 

<img width="594" alt="image" src="https://github.com/user-attachments/assets/9230d491-4130-4386-b879-4ad8c00ec8b6">

Additionally, I can not uncheck the "app data isolation" slider. 

![image](https://github.com/user-attachments/assets/0eeae05e-c57a-42ff-bdb5-c3f08ae6b147)



